### PR TITLE
update log messages

### DIFF
--- a/cypress/integration/react-selector.spec.js
+++ b/cypress/integration/react-selector.spec.js
@@ -4,25 +4,25 @@ describe('It should validate cypress react selector', () => {
     cy.waitForReact()
   })
 
-  it('it should validate react selection with component only', () => {
+  it.only('it should validate react selection with component only', () => {
     cy.react('t').should('have.length', '22')
   })
 
-  it('it should validate react selection component and props', () => {
+  it.only('it should validate react selection component and props', () => {
     cy.react('t', { name: '5' }).should('have.text', '5')
   })
 
-  it('it should validate react selection with wildcard', () => {
+  it.only('it should validate react selection with wildcard', () => {
     cy.react('*', { name: '9' }).should('have.text', '9')
   })
 
-  it('it should validate react selection with cypress find command', () => {
+  it.only('it should validate react selection with cypress find command', () => {
     cy.react('t', { name: '5' })
       .find('button')
       .should('have.text', '5')
   })
 
-  it('should calculate 7 * 6', () => {
+  it.only('should calculate 7 * 6', () => {
     cy.react('t', { name: '7' }).click()
     cy.react('t', { name: 'x' }).click()
     cy.react('t', { name: '6' }).click()


### PR DESCRIPTION
- hide `window` command
- hide read file command and add log message when ready to show that plugin's name
- added log messages when searching for component

before:
<img width="1278" alt="Screen Shot 2020-05-11 at 5 57 47 PM" src="https://user-images.githubusercontent.com/2212006/81617237-104afb80-93b3-11ea-8bfc-b7c67b45b745.png">

after:
<img width="1277" alt="Screen Shot 2020-05-11 at 6 10 02 PM" src="https://user-images.githubusercontent.com/2212006/81617252-17720980-93b3-11ea-91c9-54aa17cbaa29.png">
