### PR TITLE
Fix the type definition for `waitForReact()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,17 +11,17 @@ declare namespace Cypress {
   }
   interface Chainable {
     /**
-     *wait until the React's component tree is loaded, add the `waitForReact` method to fixture's `before` hook.
+     * Wait until the React's component tree is loaded. Call `cy.waitForReact()` in your test's `before` hook.
      * @example
-     *before(() => {
-     * cy.visit('http://localhost:3000/myApp');
-     *cy.waitForReact();
-     *});
+     * before(() => {
+     *  cy.visit('http://localhost:3000/myApp');
+     *  cy.waitForReact();
+     * });
      *
      * @param timeout
      * @param reactRoot
      */
-    waitForReact(timeout: number, reactRoot: string): Chainable<any>;
+    waitForReact(timeout?: number, reactRoot?: string): Chainable<any>;
 
     /**
      * Get react elements by component, props and states


### PR DESCRIPTION
The args to `waitForReact()` are optional, but are listed as required in the type definitions.

Also, I made some changes to the JSDoc for it. I wanted to clarify that the method itself does not add a call to a fixture, but rather you need to call the method in your test's "before" hook.