### PR TITLE
Add retry and timeout to query

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ const serializeToLog = (props) =>
  * @param {*} state
  */
 const react = (subject, component, props, state) => {
+  cy.log('subject: ' + subject + ', component: ' + component + ', props: ' + JSON.stringify(props) + ', state: ' + state);
   const startTime = Date.now();
   let logMessage = `Finding **<${markupEscape(component)}`;
   let elements;
@@ -83,10 +84,10 @@ const react = (subject, component, props, state) => {
         }
         if (!elements.length) {
           if ((Date.now() - startTime) >= Cypress.config('defaultCommandTimeout')) {
-            resolve ([]);
+            reject(new Error(`React Cypress query timed out after ${Cypress.config('defaultCommandTimeout')}ms.`))
             return;
           }
-          setTimeout(tryFind, 100);
+          setTimeout(tryFind, 250);
           return;
         }
         let nodes = [];

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const findReactRetryDelay = 250; // TODO: Find the best value for this
+
 /**
  * wait for react to be loaded
  * @param {*} timeout
@@ -46,7 +48,6 @@ const serializeToLog = (props) =>
  * @param {*} state
  */
 const react = (subject, component, props, state) => {
-  cy.log('subject: ' + subject + ', component: ' + component + ', props: ' + JSON.stringify(props) + ', state: ' + state);
   const startTime = Date.now();
   let logMessage = `Finding **<${markupEscape(component)}`;
   let elements;
@@ -65,7 +66,7 @@ const react = (subject, component, props, state) => {
       const tryFind = () => {
         if (!window.resq) {
           reject(new Error(
-            '[cypress-react-selector] not loaded yet. did you forget to run cy.waitForReact()?'
+            '[cypress-react-selector] not loaded yet. Did you forget to run cy.waitForReact()?'
           ));
           return;
         }
@@ -87,7 +88,7 @@ const react = (subject, component, props, state) => {
             reject(new Error(`React Cypress query timed out after ${Cypress.config('defaultCommandTimeout')}ms.`))
             return;
           }
-          setTimeout(tryFind, 250);
+          setTimeout(tryFind, findReactRetryDelay);
           return;
         }
         let nodes = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-react-selector",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "cypress plugin to locate react elements by component, props and state",
   "main": "./index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-react-selector",
-  "version": "1.2.0",
+  "version": "1.1.1",
   "description": "cypress plugin to locate react elements by component, props and state",
   "main": "./index.js",
   "keywords": [
@@ -19,7 +19,7 @@
     "cypress": "^4.5.0"
   },
   "dependencies": {
-    "resq": "Wine-Dark-Sea/resq#f2e30b9"
+    "resq": "^1.7.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cypress": "^4.5.0"
   },
   "dependencies": {
-    "resq": "^1.7.1"
+    "resq": "Wine-Dark-Sea/resq#f2e30b9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds the ability to retry finding a React element, as well as a timeout in case it couldn't be found. Cypress normally does this as well, but since this module uses resq it needs to be done manually. It is quite crucial for testing pages with for example short loading spinners before showing the main content, etc. The default Cypress timeout is used, so it should function how a user might expect. I'm not sure about how often to retry finding the element. Currently, it's set to 250ms, but there might be a better interval. Also, maybe there should be an option to disable the retry.

Let me know what you think.