### PR TITLE
fix: Use require.resolve to find resq

### DIFF
--- a/src/resqInjector.js
+++ b/src/resqInjector.js
@@ -6,7 +6,7 @@ const { getReactRoot } = require('./utils');
  * @param {*} reactRoot
  */
 exports.waitForReact = (timeout = 10000, reactRoot) => {
-  cy.readFile('node_modules/resq/dist/index.js', 'utf8', {
+  cy.readFile(require.resolve('resq'), 'utf8', {
     log: false,
   }).then((script) => {
     cy.window({ log: false }).then({ timeout: timeout }, (win) => {


### PR DESCRIPTION
Referencing the path directly causes issues in projects using yarn
workspaces, which may install resq in a different location.

Additionally, the direct path inclusion makes this project dependent on
internal implementation details of resq, which are subject to change.