### PR TITLE
Reset global.isReactLoaded in component testing

### DIFF
--- a/src/resqInjector.js
+++ b/src/resqInjector.js
@@ -14,6 +14,9 @@ exports.waitForReact = (timeout = 10000, reactRoot) => {
     log: false,
   }).then((script) => {
     cy.window({ log: false }).then({ timeout: timeout }, (win) => {
+      if (Cypress.testingType === 'component') {
+        global.isReactLoaded = false;
+      }
       win.eval(script);
       return new Cypress.Promise.resolve(
         win.resq.waitToLoadReact(timeout, getReactRoot(reactRoot))


### PR DESCRIPTION
When component testing, the same root element will be used for all
tests. This breaks resq's logic somewhere, but it can be fixed by
forcing resq to reload. To do this, unset `global.isReactLoaded`, only
in component testing (does not seem to be an issue in e2e testing.)

Uses the workaround described in #235 

Fixes #235

(Also, could you add the hacktoberfest-accepted label if you do merge this? Thanks!)