### PR TITLE
Fix `reactOpts.root` querying the Cypress document instead of the iframe document

### DIFF
--- a/src/reactHandler.js
+++ b/src/reactHandler.js
@@ -70,7 +70,7 @@ exports.react = (subject, component, reactOpts = {}) => {
             if (getReactRoot(reactOpts.root) !== undefined) {
               elements = window.resq.resq$$(
                 component,
-                document.querySelector(getReactRoot(reactOpts.root))
+                cy.state('window').document.querySelector(getReactRoot(reactOpts.root))
               );
             } else {
               elements = window.resq.resq$$(component);
@@ -214,7 +214,7 @@ exports.getReact = (subject, component, reactOpts = {}) => {
           if (getReactRoot(reactOpts.root) !== undefined) {
             elements = window.resq.resq$$(
               component,
-              document.querySelector(getReactRoot(reactOpts.root))
+              cy.state('window').document.querySelector(getReactRoot(reactOpts.root))
             );
           } else {
             elements = window.resq.resq$$(component);


### PR DESCRIPTION
Fix `reactOpts.root` code path that attempted to get the React root element from the Cypress window document, rather than the page being tested.

I believe this resulted in the second argument always being null or undefined.

Cypress UI also seems to use React, so it might have caused confusion.