### PR TITLE
feat: Add extra param to waitForReact (#273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ before(() => {
 });
 ```
 
+_NOTE_: If you are using Webpack with your project, you may need to manually pass in the [resq](https://www.npmjs.com/package/resq) module path.
+
+There's an optional parameter in `waitForReact` that can be passed in at runtime.
+
+This should be the path of the `resq` entrypoint
+
+```js
+before(() => {
+  cy.visit('http://localhost:3000/myApp');
+  cy.waitForReact(1000, '#root', 'node_modules/resq/dist/index.js'); // Manually passing in the resq module path
+});
+```
+
 ### Find Element by React Component
 
 You should have [React Develop Tool](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en) installed to spy and find out the component name as sometimes components can go though modifications. Once the React gets loaded, you can easily identify an web element by react component name:

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,8 +26,13 @@ declare namespace Cypress {
      *
      * @param timeout
      * @param reactRoot
+     * @param resqModulePath
      */
-    waitForReact(timeout?: number, reactRoot?: string): void;
+    waitForReact(
+      timeout?: number,
+      reactRoot?: string,
+      resqModulePath?: string
+    ): void;
 
     /**
      * Get react elements by component, props and states

--- a/src/resqInjector.js
+++ b/src/resqInjector.js
@@ -5,12 +5,15 @@ const { getReactRoot } = require('./utils');
  * @param {*} timeout
  * @param {*} reactRoot
  */
-exports.waitForReact = (timeout = 10000, reactRoot) => {
+exports.waitForReact = (timeout = 10000, reactRoot, resqModulePath) => {
   const file = require.hasOwnProperty('resolve')
     ? require.resolve('resq')
     : 'node_modules/resq/dist/index.js';
 
-  cy.readFile(file, 'utf8', {
+  // If the user passes in a resq path, use that instead
+  const resqPath = resqModulePath || file;
+
+  cy.readFile(resqPath, 'utf8', {
     log: false,
   }).then((script) => {
     cy.window({ log: false }).then({ timeout: timeout }, (win) => {


### PR DESCRIPTION
This adds an extra param to the `waitForReact` function to directly input the path to the resq loader.  This solves the issue with Webpack and allows arbitrary loading of different module resolution. 

Related issue #273 