### PR TITLE
Handle edge cases around empty results

### DIFF
--- a/src/reactHandler.js
+++ b/src/reactHandler.js
@@ -95,12 +95,18 @@ exports.react = (subject, component, reactOpts = {}) => {
           elements.forEach((elm) => {
             var node = elm.node,
               isFragment = elm.isFragment;
+            if (!node) {
+              return;
+            }
             if (isFragment) {
               nodes = nodes.concat(node);
             } else {
               nodes.push(node);
             }
           });
+          if (!nodes.length) {
+            return null;
+          }
 
           return nodes;
         }
@@ -231,6 +237,7 @@ exports.getReact = (subject, component, reactOpts = {}) => {
             exact: reactOpts.exact,
           });
         }
+        elements = elements.filter(Boolean);
         if (!elements.length) {
           return null;
         }


### PR DESCRIPTION
In my usage of this plugin, I've come across an issue where cy.react returns an array of empty (null or undefined) value(s). This is happening on a page where the component I'm querying for will not render until a certain threshold of data is loaded into the application. The behavior I expect is that cy.react keeps retrying until the element renders (or until timeout), but in practice, I find that it doesn't retry once, but it immediately returns an array of `undefined`. I suspect that there is an interim state where the component exists in the virtual dom (thus resq can find it), but has not yet been rendered to the dom.

These changes, tested against the application I'm working on, handle this case and allow the plugin to know to retry.